### PR TITLE
Add React frontend: chores dashboard with mock data, charts, and styling

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Household Chores Dashboard</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.jsx"></script>
+  </body>
+</html>

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "luc-frontend",
+  "private": true,
+  "version": "0.0.0",
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1"
+  },
+  "devDependencies": {
+    "@vitejs/plugin-react": "^4.3.1",
+    "vite": "^5.4.1"
+  }
+}

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,0 +1,98 @@
+import AllowanceSummary from './components/AllowanceSummary.jsx';
+import ChoresList from './components/ChoresList.jsx';
+import DailyProgressChart from './components/DailyProgressChart.jsx';
+import WeeklyProgressChart from './components/WeeklyProgressChart.jsx';
+import { chores, completions, people } from './data/chores.js';
+
+const toIsoDate = (date) => date.toISOString().slice(0, 10);
+
+const buildWeekDays = () => {
+  const today = new Date();
+  return Array.from({ length: 7 }, (_, index) => {
+    const date = new Date(today);
+    date.setDate(today.getDate() - (6 - index));
+    return toIsoDate(date);
+  });
+};
+
+export default function App() {
+  const weekDays = buildWeekDays();
+  const weekDaySet = new Set(weekDays);
+  const choreMap = new Map(chores.map((chore) => [chore.id, chore]));
+  const today = weekDays[weekDays.length - 1];
+
+  const weekCompletions = completions.filter((completion) => weekDaySet.has(completion.date));
+
+  const completionsByPerson = weekCompletions.reduce((acc, completion) => {
+    acc[completion.personId] = (acc[completion.personId] || 0) + completion.count;
+    return acc;
+  }, {});
+
+  const totalsByDay = weekCompletions.reduce((acc, completion) => {
+    if (!acc[completion.date]) {
+      acc[completion.date] = {};
+    }
+    acc[completion.date][completion.personId] =
+      (acc[completion.date][completion.personId] || 0) + completion.count;
+    return acc;
+  }, {});
+
+  const dailyTotalsByPerson = weekCompletions
+    .filter((completion) => completion.date === today)
+    .reduce((acc, completion) => {
+      acc[completion.personId] = (acc[completion.personId] || 0) + completion.count;
+      return acc;
+    }, {});
+
+  const allowanceTotalsByPerson = weekCompletions.reduce((acc, completion) => {
+    const chore = choreMap.get(completion.choreId);
+    const amount = chore ? chore.rate * completion.count : 0;
+    acc[completion.personId] = (acc[completion.personId] || 0) + amount;
+    return acc;
+  }, {});
+
+  const weeklyAllowanceTotal = Object.values(allowanceTotalsByPerson).reduce(
+    (sum, amount) => sum + amount,
+    0
+  );
+
+  return (
+    <div className="app">
+      <header className="hero">
+        <div>
+          <p className="eyebrow">Household Dashboard</p>
+          <h1>Chores & Allowance Overview</h1>
+          <p>Track weekly progress, daily completions, and allowance totals.</p>
+        </div>
+        <div className="hero-card">
+          <h3>Weekly Snapshot</h3>
+          <div className="hero-stats">
+            {people.map((person) => (
+              <div key={person.id}>
+                <span className="stat-label">{person.name}</span>
+                <span className="stat-value">
+                  {completionsByPerson[person.id] || 0} chores
+                </span>
+              </div>
+            ))}
+          </div>
+        </div>
+      </header>
+
+      <main className="dashboard-grid">
+        <ChoresList
+          chores={chores}
+          people={people}
+          completionsByPerson={completionsByPerson}
+        />
+        <WeeklyProgressChart days={weekDays} people={people} totalsByDay={totalsByDay} />
+        <DailyProgressChart date={today} people={people} totalsByPerson={dailyTotalsByPerson} />
+        <AllowanceSummary
+          total={weeklyAllowanceTotal}
+          totalsByPerson={allowanceTotalsByPerson}
+          people={people}
+        />
+      </main>
+    </div>
+  );
+}

--- a/frontend/src/components/AllowanceSummary.jsx
+++ b/frontend/src/components/AllowanceSummary.jsx
@@ -1,0 +1,25 @@
+const formatCurrency = (value) =>
+  value.toLocaleString(undefined, { style: 'currency', currency: 'USD' });
+
+export default function AllowanceSummary({ total, totalsByPerson, people }) {
+  return (
+    <div className="card allowance-card">
+      <div className="card-header">
+        <h2>Weekly Allowance Total</h2>
+        <p>Current week payout summary</p>
+      </div>
+      <div className="allowance-total">
+        <span className="amount">{formatCurrency(total)}</span>
+        <span className="label">Total earned this week</span>
+      </div>
+      <div className="allowance-breakdown">
+        {people.map((person) => (
+          <div key={person.id} className="allowance-row">
+            <span>{person.name}</span>
+            <span>{formatCurrency(totalsByPerson[person.id] || 0)}</span>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/ChoresList.jsx
+++ b/frontend/src/components/ChoresList.jsx
@@ -1,0 +1,34 @@
+export default function ChoresList({ chores, people, completionsByPerson }) {
+  return (
+    <div className="card">
+      <div className="card-header">
+        <h2>Chores & Completion Counts</h2>
+        <p>Per-person summary for the week</p>
+      </div>
+      <div className="chores-list">
+        {people.map((person) => {
+          const personChores = chores.filter((chore) => chore.personId === person.id);
+          return (
+            <div key={person.id} className="chores-person">
+              <div className="person-heading">
+                <span className="color-dot" style={{ backgroundColor: person.color }} />
+                <div>
+                  <h3>{person.name}</h3>
+                  <p>{completionsByPerson[person.id] || 0} completions</p>
+                </div>
+              </div>
+              <ul>
+                {personChores.map((chore) => (
+                  <li key={chore.id}>
+                    <span>{chore.name}</span>
+                    <span>${chore.rate.toFixed(2)}</span>
+                  </li>
+                ))}
+              </ul>
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/DailyProgressChart.jsx
+++ b/frontend/src/components/DailyProgressChart.jsx
@@ -1,0 +1,39 @@
+const formatDate = (dateString) => {
+  const date = new Date(dateString);
+  return date.toLocaleDateString(undefined, {
+    weekday: 'long',
+    month: 'short',
+    day: 'numeric',
+  });
+};
+
+export default function DailyProgressChart({ date, people, totalsByPerson }) {
+  const maxTotal = Math.max(1, ...people.map((person) => totalsByPerson[person.id] || 0));
+
+  return (
+    <div className="card">
+      <div className="card-header">
+        <h2>Daily Progress</h2>
+        <p>{formatDate(date)}</p>
+      </div>
+      <div className="daily-chart">
+        {people.map((person) => {
+          const count = totalsByPerson[person.id] || 0;
+          const width = (count / maxTotal) * 100;
+          return (
+            <div key={person.id} className="daily-row">
+              <span className="label">{person.name}</span>
+              <div className="daily-bar">
+                <div
+                  className="daily-fill"
+                  style={{ width: `${width}%`, backgroundColor: person.color }}
+                />
+              </div>
+              <span className="count">{count}</span>
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/WeeklyProgressChart.jsx
+++ b/frontend/src/components/WeeklyProgressChart.jsx
@@ -1,0 +1,49 @@
+const getDayLabel = (dateString) => {
+  const date = new Date(dateString);
+  return date.toLocaleDateString(undefined, { weekday: 'short' });
+};
+
+export default function WeeklyProgressChart({ days, people, totalsByDay }) {
+  const maxTotal = Math.max(
+    1,
+    ...days.map((day) =>
+      people.reduce((sum, person) => sum + (totalsByDay[day]?.[person.id] || 0), 0)
+    )
+  );
+
+  return (
+    <div className="card">
+      <div className="card-header">
+        <h2>Weekly Progress</h2>
+        <p>Completions per day (stacked by person)</p>
+      </div>
+      <div className="weekly-chart">
+        {days.map((day) => {
+          const dayTotal = people.reduce(
+            (sum, person) => sum + (totalsByDay[day]?.[person.id] || 0),
+            0
+          );
+          return (
+            <div key={day} className="weekly-chart-column">
+              <div className="weekly-bar" aria-label={`${day} total ${dayTotal}`}>
+                {people.map((person) => {
+                  const count = totalsByDay[day]?.[person.id] || 0;
+                  const height = (count / maxTotal) * 100;
+                  return (
+                    <div
+                      key={person.id}
+                      className="weekly-segment"
+                      style={{ height: `${height}%`, backgroundColor: person.color }}
+                      title={`${person.name}: ${count}`}
+                    />
+                  );
+                })}
+              </div>
+              <span>{getDayLabel(day)}</span>
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/data/chores.js
+++ b/frontend/src/data/chores.js
@@ -1,0 +1,36 @@
+const isoDate = (date) => date.toISOString().slice(0, 10);
+const daysAgo = (days) => {
+  const date = new Date();
+  date.setDate(date.getDate() - days);
+  return isoDate(date);
+};
+
+export const people = [
+  { id: 'alex', name: 'Alex', color: '#4f46e5' },
+  { id: 'jamie', name: 'Jamie', color: '#0ea5e9' },
+  { id: 'riley', name: 'Riley', color: '#f97316' },
+];
+
+export const chores = [
+  { id: 'dishes', name: 'Dishes', personId: 'alex', rate: 1.5 },
+  { id: 'laundry', name: 'Laundry', personId: 'jamie', rate: 2.0 },
+  { id: 'vacuum', name: 'Vacuum', personId: 'riley', rate: 1.75 },
+  { id: 'trash', name: 'Trash & Recycling', personId: 'alex', rate: 1.0 },
+  { id: 'bathroom', name: 'Bathroom', personId: 'jamie', rate: 2.5 },
+  { id: 'yard', name: 'Yard', personId: 'riley', rate: 3.0 },
+];
+
+export const completions = [
+  { id: 'c1', choreId: 'dishes', personId: 'alex', date: daysAgo(0), count: 2 },
+  { id: 'c2', choreId: 'trash', personId: 'alex', date: daysAgo(1), count: 1 },
+  { id: 'c3', choreId: 'laundry', personId: 'jamie', date: daysAgo(0), count: 1 },
+  { id: 'c4', choreId: 'bathroom', personId: 'jamie', date: daysAgo(2), count: 1 },
+  { id: 'c5', choreId: 'vacuum', personId: 'riley', date: daysAgo(1), count: 1 },
+  { id: 'c6', choreId: 'yard', personId: 'riley', date: daysAgo(3), count: 1 },
+  { id: 'c7', choreId: 'dishes', personId: 'alex', date: daysAgo(4), count: 2 },
+  { id: 'c8', choreId: 'laundry', personId: 'jamie', date: daysAgo(4), count: 1 },
+  { id: 'c9', choreId: 'vacuum', personId: 'riley', date: daysAgo(5), count: 1 },
+  { id: 'c10', choreId: 'trash', personId: 'alex', date: daysAgo(6), count: 1 },
+  { id: 'c11', choreId: 'bathroom', personId: 'jamie', date: daysAgo(6), count: 1 },
+  { id: 'c12', choreId: 'yard', personId: 'riley', date: daysAgo(2), count: 1 },
+];

--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import App from './App.jsx';
+import './styles.css';
+
+ReactDOM.createRoot(document.getElementById('root')).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+);

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -1,0 +1,254 @@
+:root {
+  font-family: 'Inter', system-ui, sans-serif;
+  line-height: 1.5;
+  font-weight: 400;
+  color: #0f172a;
+  background-color: #f8fafc;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+}
+
+#root {
+  min-height: 100vh;
+}
+
+.app {
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: 32px 20px 48px;
+}
+
+.hero {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 24px;
+  justify-content: space-between;
+  align-items: flex-start;
+  margin-bottom: 32px;
+}
+
+.hero h1 {
+  margin: 8px 0 12px;
+  font-size: clamp(2rem, 4vw, 2.75rem);
+}
+
+.hero p {
+  margin: 0;
+  color: #475569;
+}
+
+.eyebrow {
+  text-transform: uppercase;
+  letter-spacing: 0.2em;
+  font-size: 0.75rem;
+  color: #94a3b8;
+}
+
+.hero-card {
+  background: #0f172a;
+  color: #f8fafc;
+  padding: 20px 24px;
+  border-radius: 16px;
+  min-width: 260px;
+  box-shadow: 0 20px 40px rgba(15, 23, 42, 0.15);
+}
+
+.hero-card h3 {
+  margin: 0 0 16px;
+}
+
+.hero-stats {
+  display: grid;
+  gap: 12px;
+}
+
+.stat-label {
+  display: block;
+  font-size: 0.75rem;
+  color: #94a3b8;
+}
+
+.stat-value {
+  font-size: 1.1rem;
+  font-weight: 600;
+}
+
+.dashboard-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: 24px;
+}
+
+.card {
+  background: white;
+  border-radius: 16px;
+  padding: 20px 22px;
+  box-shadow: 0 12px 32px rgba(15, 23, 42, 0.08);
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.card-header h2 {
+  margin: 0;
+  font-size: 1.2rem;
+}
+
+.card-header p {
+  margin: 4px 0 0;
+  color: #64748b;
+  font-size: 0.9rem;
+}
+
+.chores-list {
+  display: grid;
+  gap: 16px;
+}
+
+.chores-person {
+  border: 1px solid #e2e8f0;
+  border-radius: 12px;
+  padding: 16px;
+}
+
+.chores-person ul {
+  list-style: none;
+  padding: 0;
+  margin: 12px 0 0;
+  display: grid;
+  gap: 8px;
+}
+
+.chores-person li {
+  display: flex;
+  justify-content: space-between;
+  color: #475569;
+}
+
+.person-heading {
+  display: flex;
+  gap: 12px;
+  align-items: center;
+}
+
+.person-heading h3 {
+  margin: 0;
+}
+
+.color-dot {
+  width: 14px;
+  height: 14px;
+  border-radius: 50%;
+}
+
+.weekly-chart {
+  display: grid;
+  grid-template-columns: repeat(7, 1fr);
+  gap: 12px;
+  align-items: end;
+  height: 220px;
+}
+
+.weekly-chart-column {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 8px;
+  font-size: 0.8rem;
+  color: #64748b;
+}
+
+.weekly-bar {
+  width: 100%;
+  height: 160px;
+  display: flex;
+  flex-direction: column-reverse;
+  justify-content: flex-start;
+  border-radius: 12px;
+  background: #f1f5f9;
+  overflow: hidden;
+}
+
+.weekly-segment {
+  width: 100%;
+}
+
+.daily-chart {
+  display: grid;
+  gap: 12px;
+}
+
+.daily-row {
+  display: grid;
+  grid-template-columns: 80px 1fr 32px;
+  gap: 12px;
+  align-items: center;
+  font-size: 0.9rem;
+  color: #475569;
+}
+
+.daily-bar {
+  height: 10px;
+  border-radius: 999px;
+  background: #e2e8f0;
+  overflow: hidden;
+}
+
+.daily-fill {
+  height: 100%;
+  border-radius: 999px;
+}
+
+.allowance-card {
+  background: linear-gradient(135deg, #1e293b, #0f172a);
+  color: #f8fafc;
+}
+
+.allowance-card .card-header p {
+  color: #cbd5f5;
+}
+
+.allowance-total {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.allowance-total .amount {
+  font-size: 2rem;
+  font-weight: 700;
+}
+
+.allowance-total .label {
+  font-size: 0.9rem;
+  color: #cbd5f5;
+}
+
+.allowance-breakdown {
+  display: grid;
+  gap: 10px;
+}
+
+.allowance-row {
+  display: flex;
+  justify-content: space-between;
+  font-size: 0.95rem;
+}
+
+@media (max-width: 720px) {
+  .hero {
+    flex-direction: column;
+  }
+
+  .weekly-chart {
+    grid-template-columns: repeat(4, 1fr);
+    height: auto;
+  }
+}

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -1,0 +1,6 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+});


### PR DESCRIPTION
### Motivation
- Provide a lightweight React dashboard to visualize household chores, per-person completion counts, daily/weekly progress, and weekly allowance totals using local mock data.

### Description
- Scaffold a React + Vite frontend under `frontend/` with `package.json`, `vite.config.js`, `index.html`, and the app entry `src/main.jsx`.
- Add mock data in `src/data/chores.js` containing `people`, `chores`, and `completions` (with allowance rates and date helpers).
- Implement dashboard UI components: `ChoresList.jsx`, `WeeklyProgressChart.jsx`, `DailyProgressChart.jsx`, and `AllowanceSummary.jsx`, and wire them in `src/App.jsx` where weekly/daily totals and allowance sums are derived from the mock data.
- Include layout and styling in `src/styles.css` for cards, charts, and responsive grid layout.

### Testing
- Attempted to scaffold with `npm create vite` but the command failed due to registry permission (`403 Forbidden`).
- Attempted `cd frontend && npm install` to install dependencies but the install failed with `403 Forbidden` from the npm registry, so no build or runtime tests were executed.
- No automated tests were run because dependency installation and the dev server could not be started due to the registry access error.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697eb024cc80832e9ed386a556e86393)