### PR TITLE
Add chores models, aggregation utilities, and dashboard chart builder

### DIFF
--- a/src/dashboard.ts
+++ b/src/dashboard.ts
@@ -1,0 +1,44 @@
+import type { AllowanceRule, Completion } from "./models/chores";
+import {
+  computeDailyTotals,
+  computeWeeklyAllowanceTotals,
+  computeWeeklyTotals,
+} from "./utils/aggregation";
+
+type ChartPoint = { x: string; y: number };
+type ChartSeries = { label: string; data: ChartPoint[] };
+
+const toSeries = (totals: Record<string, Record<string, number>>): ChartSeries[] => {
+  const allKeys = new Set<string>();
+  Object.values(totals).forEach((inner) => {
+    Object.keys(inner).forEach((key) => allKeys.add(key));
+  });
+
+  const labels = Array.from(allKeys).sort();
+  const outerKeys = Object.keys(totals).sort();
+
+  return labels.map((label) => ({
+    label,
+    data: outerKeys.map((outerKey) => ({
+      x: outerKey,
+      y: totals[outerKey]?.[label] ?? 0,
+    })),
+  }));
+};
+
+export const buildDashboardChartData = (
+  completions: Completion[],
+  rules: AllowanceRule[],
+) => {
+  const dailyTotals = computeDailyTotals(completions);
+  const weeklyTotals = computeWeeklyTotals(completions);
+  const weeklyAllowanceTotals = computeWeeklyAllowanceTotals(completions, rules);
+
+  return {
+    dailyPerPerson: toSeries(dailyTotals.perPerson),
+    dailyPerChore: toSeries(dailyTotals.perChore),
+    weeklyPerPerson: toSeries(weeklyTotals.perPerson),
+    weeklyPerChore: toSeries(weeklyTotals.perChore),
+    weeklyAllowancePerPerson: toSeries(weeklyAllowanceTotals),
+  };
+};

--- a/src/models/chores.ts
+++ b/src/models/chores.ts
@@ -1,0 +1,22 @@
+export type Person = {
+  id: string;
+  name: string;
+};
+
+export type Chore = {
+  id: string;
+  name: string;
+};
+
+export type Completion = {
+  id: string;
+  personId: string;
+  choreId: string;
+  completedAt: string;
+  count?: number;
+};
+
+export type AllowanceRule = {
+  choreId: string;
+  rate: number;
+};

--- a/src/utils/aggregation.ts
+++ b/src/utils/aggregation.ts
@@ -1,0 +1,94 @@
+import type { AllowanceRule, Completion } from "../models/chores";
+
+type TotalsByKey = Record<string, Record<string, number>>;
+
+const asDate = (value: string) => {
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) {
+    throw new Error(`Invalid date value: ${value}`);
+  }
+  return date;
+};
+
+const toDateKey = (value: string) => {
+  const date = asDate(value);
+  return date.toISOString().slice(0, 10);
+};
+
+const toWeekKey = (value: string) => {
+  const date = asDate(value);
+  const day = date.getUTCDay();
+  const diff = (day + 6) % 7;
+  const monday = new Date(Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), date.getUTCDate()));
+  monday.setUTCDate(monday.getUTCDate() - diff);
+  return monday.toISOString().slice(0, 10);
+};
+
+const addToTotals = (totals: TotalsByKey, outerKey: string, innerKey: string, amount: number) => {
+  if (!totals[outerKey]) {
+    totals[outerKey] = {};
+  }
+  totals[outerKey][innerKey] = (totals[outerKey][innerKey] ?? 0) + amount;
+};
+
+const completionCount = (completion: Completion) => completion.count ?? 1;
+
+export type DailyTotals = {
+  perPerson: TotalsByKey;
+  perChore: TotalsByKey;
+};
+
+export type WeeklyTotals = {
+  perPerson: TotalsByKey;
+  perChore: TotalsByKey;
+};
+
+export type WeeklyAllowanceTotals = Record<string, Record<string, number>>;
+
+export const computeDailyTotals = (completions: Completion[]): DailyTotals => {
+  const perPerson: TotalsByKey = {};
+  const perChore: TotalsByKey = {};
+
+  completions.forEach((completion) => {
+    const dateKey = toDateKey(completion.completedAt);
+    const count = completionCount(completion);
+    addToTotals(perPerson, dateKey, completion.personId, count);
+    addToTotals(perChore, dateKey, completion.choreId, count);
+  });
+
+  return { perPerson, perChore };
+};
+
+export const computeWeeklyTotals = (completions: Completion[]): WeeklyTotals => {
+  const perPerson: TotalsByKey = {};
+  const perChore: TotalsByKey = {};
+
+  completions.forEach((completion) => {
+    const weekKey = toWeekKey(completion.completedAt);
+    const count = completionCount(completion);
+    addToTotals(perPerson, weekKey, completion.personId, count);
+    addToTotals(perChore, weekKey, completion.choreId, count);
+  });
+
+  return { perPerson, perChore };
+};
+
+export const computeWeeklyAllowanceTotals = (
+  completions: Completion[],
+  rules: AllowanceRule[],
+): WeeklyAllowanceTotals => {
+  const rateByChore = new Map(rules.map((rule) => [rule.choreId, rule.rate]));
+  const totals: WeeklyAllowanceTotals = {};
+
+  completions.forEach((completion) => {
+    const rate = rateByChore.get(completion.choreId);
+    if (rate === undefined) {
+      return;
+    }
+    const weekKey = toWeekKey(completion.completedAt);
+    const amount = completionCount(completion) * rate;
+    addToTotals(totals, weekKey, completion.personId, amount);
+  });
+
+  return totals;
+};


### PR DESCRIPTION
### Motivation
- Provide canonical TypeScript models for chores data to share types across the app. 
- Compute daily and weekly rollups and allowance totals from raw `Completion` records to drive UI charts and summaries. 
- Offer a small dashboard adapter that converts aggregation output into chart-ready series.

### Description
- Added `src/models/chores.ts` containing `Person`, `Chore`, `Completion`, and `AllowanceRule` type definitions. 
- Added `src/utils/aggregation.ts` implementing `computeDailyTotals`, `computeWeeklyTotals`, and `computeWeeklyAllowanceTotals`, plus helper functions `toDateKey`, `toWeekKey` (ISO date keys with Monday-week anchoring), `asDate`, and `addToTotals`. 
- Added `src/dashboard.ts` with `toSeries` and `buildDashboardChartData` which consume the aggregation utilities and produce chart series (`{label, data: [{x,y}]}`) for daily/weekly per-person, per-chore, and weekly allowance views. 

### Testing
- No automated tests were run as part of this change (no test suite executed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697eb02a50b8832ebc142626b3174369)